### PR TITLE
fix(ios): autolinking when using Xcode 12

### DIFF
--- a/react-native-viewpager.podspec
+++ b/react-native-viewpager.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
# Summary

https://github.com/react-native-community/react-native-webview/pull/1643

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] I have tested this on a XCode 12