### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ const styles = StyleSheet.create({
 });
 ```
 
+**Attention:** Note that you can only use `View` components as children of `ViewPager` (cf. folder */example*)
+
 ## API
 
 |Prop|Description|Platform|


### PR DESCRIPTION
clarify that you can only use View components as children of ViewPager

As a beginner it took me some time to understand that only View components can be used as children of ViewPager
So I think a short remark/note in the ReadMe would be helpful for beginners.
