### PR TITLE
Add missing RCTEventDispatcher import

### DIFF
--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -1,4 +1,4 @@
-
+#import <React/RCTEventDispatcher.h>
 #import <React/RCTShadowView.h>
 #import <React/UIView+React.h>
 #import <UIKit/UIKit.h>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Add the import for RCTEventDispatcher, it seems like it is no longer transitively imported from RCTViewManager. It is better to explicitly import it anyway.

## Test Plan

Tested that adding this import fixes my app build that is based on RN master.

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

## Compatibility

N/A

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
