### PR TITLE
Fix Android multiple pager instances

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
@@ -9,6 +9,8 @@ import androidx.fragment.app.FragmentActivity;
 import com.reactnative.community.viewpager2.adapter.FragmentStateAdapter;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class FragmentAdapter extends FragmentStateAdapter {
 
@@ -57,6 +59,10 @@ public class FragmentAdapter extends FragmentStateAdapter {
     public void removeAll() {
         childrenViewIDs.clear();
         notifyDataSetChanged();
+    }
+
+    public List<Integer> getChildrenViewIDs() {
+        return Collections.unmodifiableList(childrenViewIDs);
     }
 
     public int getChildViewIDAt(int index) {

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -127,7 +127,9 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
 
     public void removeAllViews(ViewPager2 parent) {
         FragmentAdapter adapter = ((FragmentAdapter) parent.getAdapter());
-        reactChildrenViews.clear();
+        for (int childID : adapter.getChildrenViewIDs()) {
+            reactChildrenViews.remove(childID);
+        }
         adapter.removeAll();
         parent.setAdapter(null);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When there are multiple pagers, especially if some are dynamically created/removed, pages can disappear.  This only occurs on Android due to clearing the entire static array.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ (already works)     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
