### PR TITLE
Fix Xcode build warning about IPHONEOS_DEPLOYMENT_TARGET

### DIFF
--- a/react-native-viewpager.podspec
+++ b/react-native-viewpager.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package['author']
   s.homepage     = package['homepage']
 
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/react-native-community/react-native-viewpager.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true


### PR DESCRIPTION
# Summary

When running a build on the command line, I get the following warning:
```
warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 7.0, but the range of supported deployment target versions is 8.0 to 13.7.99. (in target 'react-native-viewpager' from project 'Pods')
```

Since the recent iOS minimum for React Native is 9.0, I updated the .podspec to match it.

## Test Plan

1. Updated the podspec in my application's `node_modules` folder.
2. Ran an Xcode build.
3. Verified no warnings about `IPHONEOS_DEPLOYMENT_TARGET`

### What's required for testing (prerequisites)?
N/A

### What are the steps to reproduce (after prerequisites)?
N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
