### PR TITLE
Add offscreen page limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ const styles = StyleSheet.create({
 |`transitionStyle: TransitionStyle`|Use `scroll` or `curl` to change transition style (it does **not** work dynamically)|iOS
 |`showPageIndicator: boolean`|Shows the dots indicator at the bottom of the view|iOS
 |`overScrollMode: OverScollMode`|Used to override default value of overScroll mode. Can be `auto`, `always` or `never`. Defaults to `auto`|Android
+|`offscreenPageLimit: number`|Set the number of pages that should be retained to either side of the currently visible page(s). Pages beyond this limit will be recreated from the adapter when needed. Defaults to RecyclerView's caching strategy. The given value must either be larger than 0.|Android
 
 ## Preview
 

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -53,6 +53,11 @@ public class ReactViewPagerManager extends ViewGroupManager<ReactViewPager> {
         viewPager.setOrientation(value.equals("vertical"));
     }
 
+    @ReactProp(name = "offscreenPageLimit", defaultInt = ViewPager2.OFFSCREEN_PAGE_LIMIT_DEFAULT)
+    public void set(ViewPager2 viewPager, int value) {
+        viewPager.setOffscreenPageLimit(value);
+    }
+
     @ReactProp(name = "overScrollMode")
     public void setOverScrollMode(ReactViewPager viewPager, String value) {
         if (value.equals("never")) {

--- a/js/types.js
+++ b/js/types.js
@@ -100,6 +100,15 @@ export type ViewPagerProps = $ReadOnly<{|
    */
   scrollEnabled?: ?boolean,
 
+  /**
+   * Set the number of pages that should be retained to either side
+   * of the currently visible page(s). Pages beyond this limit will
+   * be recreated from the adapter when needed.
+   * Defaults to RecyclerView's caching strategy.
+   * The given value must either be larger than 0.
+   */
+  offscreenPageLimit?: ?number,
+
   children?: Node,
 
   style?: ?ViewStyleProp,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -28,6 +28,15 @@ export interface ViewPagerProps {
     scrollEnabled?: boolean;
 
     /**
+     * Set the number of pages that should be retained to either side
+     * of the currently visible page(s). Pages beyond this limit will
+     * be recreated from the adapter when needed.
+     * Defaults to RecyclerView's caching strategy.
+     * The given value must either be larger than 0.
+     */
+    offscreenPageLimit?: ?number,
+
+    /**
      * Executed when transitioning between pages (ether because of animation for
      * the requested page change or when user is swiping/dragging between pages)
      * The `event.nativeEvent` object for this callback will carry following data:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I need this so deeply https://developer.android.com/reference/androidx/viewpager2/widget/ViewPager2#setOffscreenPageLimit(int)
Basically, I have a ton of things rendered on pages and do not want to optimize it, because it leads to some minor glitches 


Before: 
https://streamable.com/psex6e


After:
https://streamable.com/nq5yvb

## Test Plan

Doesn't have too much impact unless the app is really packed with components. 


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
