### PR TITLE
fix: add android pageMargin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
-    implementation 'com.github.troZee:ViewPager2:v1.0.6'
-
+    implementation 'com.github.troZee:ViewPager2:v1.0.7'
 }

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -25,6 +25,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.reactnative.community.viewpager2.widget.MarginPageTransformer;
 import com.reactnative.community.viewpager2.widget.ViewPager2;
 import com.reactnativecommunity.viewpager.event.PageScrollEvent;
 import com.reactnativecommunity.viewpager.event.PageScrollStateChangedEvent;
@@ -222,7 +223,8 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
     @ReactProp(name = "pageMargin", defaultFloat = 0)
     public void setPageMargin(ViewPager2 pager, float margin) {
         int pageMargin = (int) PixelUtil.toPixelFromDIP(margin);
-        pager.setPadding(pageMargin, pageMargin, pageMargin, pageMargin);
+        pager.setPageTransformer(new MarginPageTransformer(pageMargin));
     }
+
 
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -236,7 +236,7 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-viewpager (4.1.3):
+  - react-native-viewpager (5.0.2):
     - React
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
@@ -450,7 +450,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-viewpager: fdf68386dfb6fc4e702f32d054e662ae9a7f11c2
+  react-native-viewpager: e91997277c539a1175c42b39cfe931e4e641b536
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13


### PR DESCRIPTION
Fix for issue https://github.com/callstack/react-native-viewpager/issues/231

## Test Plan
![image](https://user-images.githubusercontent.com/16048381/100860156-6fc44200-3490-11eb-835c-3f790a027dd5.png)

### What are the steps to reproduce (after prerequisites)?
Prepare testing component with this body:
```jsx
      <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
        <ViewPager pageMargin={24} style={{flex: 1}}>
          <View style={{flex: 1, backgroundColor: 'red'}} />
          <View style={{flex: 1, backgroundColor: 'blue'}} />
        </ViewPager>
        <View style={{flex: 1, backgroundColor: 'yellow'}} />
        <ViewPager pageMargin={24} style={{flex: 1}} orientation="vertical">
          <View style={{flex: 1, backgroundColor: 'green'}} />
          <View style={{flex: 1, backgroundColor: 'tomato'}} />
        </ViewPager>
      </SafeAreaView>
```
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator
