### PR TITLE
fix: prevent touch events to be executed during swipe

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
-    implementation 'com.github.troZee:ViewPager2:v1.0.7'
+    implementation 'androidx.viewpager2:viewpager2:1.0.0'
 }

--- a/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
@@ -1,6 +1,7 @@
 package com.reactnativecommunity.viewpager;
 
 import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
@@ -13,60 +14,59 @@ import java.util.Collections;
 import java.util.List;
 
 public class FragmentAdapter extends FragmentStateAdapter {
-
+    private List<View> childrenViews = new ArrayList<>();
     public FragmentAdapter(@NonNull FragmentActivity fragmentActivity) {
         super(fragmentActivity);
     }
-
-    private ArrayList<Integer> childrenViewIDs = new ArrayList<>();
 
 
     @NonNull
     @Override
     public Fragment createFragment(int position) {
-        return ViewPagerFragment.newInstance(childrenViewIDs.get(position));
+        return new ViewPagerFragment(childrenViews.get(position));
     }
 
     @Override
     public int getItemCount() {
-        return childrenViewIDs.size();
+        return childrenViews.size();
     }
 
     @Override
     public long getItemId(int position) {
-        return childrenViewIDs.get(position);
+        return childrenViews.get(position).getId();
     }
 
     @Override
     public boolean containsItem(long itemId) {
-        return childrenViewIDs.contains((int) itemId);
+        for(View child: childrenViews) {
+            if((int) itemId == child.getId()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void addFragment(View child, int index) {
-        childrenViewIDs.add(index, child.getId());
+        childrenViews.add(index, child);
         notifyItemInserted(index);
     }
 
     public void removeFragment(View child) {
-        int index = childrenViewIDs.indexOf(child.getId());
+        int index = childrenViews.indexOf(child);
         removeFragmentAt(index);
     }
 
     public void removeFragmentAt(int index) {
-        childrenViewIDs.remove(index);
+        childrenViews.remove(index);
         notifyItemRemoved(index);
     }
 
     public void removeAll() {
-        childrenViewIDs.clear();
+        childrenViews.clear();
         notifyDataSetChanged();
     }
 
-    public List<Integer> getChildrenViewIDs() {
-        return Collections.unmodifiableList(childrenViewIDs);
-    }
-
-    public int getChildViewIDAt(int index) {
-        return childrenViewIDs.get(index);
+    public View getChildViewAt(int index) {
+        return childrenViews.get(index);
     }
 }

--- a/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
@@ -5,8 +5,8 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
 
-import com.reactnative.community.viewpager2.adapter.FragmentStateAdapter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,6 +19,7 @@ public class FragmentAdapter extends FragmentStateAdapter {
     }
 
     private ArrayList<Integer> childrenViewIDs = new ArrayList<>();
+
 
     @NonNull
     @Override

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -14,6 +14,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+import androidx.viewpager2.widget.MarginPageTransformer;
+import androidx.viewpager2.widget.ViewPager2;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReadableArray;
@@ -25,18 +28,16 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
-import com.reactnative.community.viewpager2.widget.MarginPageTransformer;
-import com.reactnative.community.viewpager2.widget.ViewPager2;
 import com.reactnativecommunity.viewpager.event.PageScrollEvent;
 import com.reactnativecommunity.viewpager.event.PageScrollStateChangedEvent;
 import com.reactnativecommunity.viewpager.event.PageSelectedEvent;
 
 import java.util.Map;
 
-import static com.reactnative.community.viewpager2.widget.ViewPager2.ORIENTATION_HORIZONTAL;
-import static com.reactnative.community.viewpager2.widget.ViewPager2.SCROLL_STATE_DRAGGING;
-import static com.reactnative.community.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE;
-import static com.reactnative.community.viewpager2.widget.ViewPager2.SCROLL_STATE_SETTLING;
+import static androidx.viewpager2.widget.ViewPager2.ORIENTATION_HORIZONTAL;
+import static androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_DRAGGING;
+import static androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE;
+import static androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_SETTLING;
 
 public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
 
@@ -57,8 +58,8 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
     @Override
     protected ViewPager2 createViewInstance(@NonNull ThemedReactContext reactContext) {
         final ViewPager2 vp = new ViewPager2(reactContext);
-        FragmentAdapter adapter = new FragmentAdapter((FragmentActivity) reactContext.getCurrentActivity());
-        vp.setAdapter(adapter);
+        final FragmentAdapter adapter = new FragmentAdapter((FragmentActivity) reactContext.getCurrentActivity());
+        vp.setAdapter((FragmentStateAdapter) adapter);
         eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         vp.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override
@@ -98,6 +99,20 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
         });
         return vp;
     }
+
+    private void setCurrentItem(final ViewPager2 view, int selectedTab, boolean scrollSmooth) {
+        view.post(new Runnable() {
+            @Override
+            public void run() {
+                view.measure(
+                        View.MeasureSpec.makeMeasureSpec(view.getWidth(), View.MeasureSpec.EXACTLY),
+                        View.MeasureSpec.makeMeasureSpec(view.getHeight(), View.MeasureSpec.EXACTLY));
+                view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
+            }
+        });
+        view.setCurrentItem(selectedTab);
+    }
+
 
     @Override
     public void addView(ViewPager2 parent, View child, int index) {
@@ -197,13 +212,13 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
         Assertions.assertNotNull(args);
         switch (commandId) {
             case COMMAND_SET_PAGE: {
-                root.setCurrentItem(args.getInt(0), true);
+                setCurrentItem(root, args.getInt(0), true);
                 eventDispatcher.dispatchEvent(new PageSelectedEvent(root.getId(), args.getInt(0)));
                 return;
 
             }
             case COMMAND_SET_PAGE_WITHOUT_ANIMATION: {
-                root.setCurrentItem(args.getInt(0), false);
+                setCurrentItem(root, args.getInt(0), false);
                 eventDispatcher.dispatchEvent(new PageSelectedEvent(root.getId(), args.getInt(0)));
                 return;
             }

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -46,7 +46,6 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
     private static final int COMMAND_SET_PAGE_WITHOUT_ANIMATION = 2;
     private static final int COMMAND_SET_SCROLL_ENABLED = 3;
     private EventDispatcher eventDispatcher;
-    static SparseArray<View> reactChildrenViews = new SparseArray<>();
 
     @NonNull
     @Override
@@ -119,7 +118,6 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
         if (child == null) {
             return;
         }
-        reactChildrenViews.put(child.getId(), child);
         ((FragmentAdapter) parent.getAdapter()).addFragment(child, index);
     }
 
@@ -131,21 +129,17 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
 
     @Override
     public View getChildAt(ViewPager2 parent, int index) {
-        return reactChildrenViews.get(((FragmentAdapter) parent.getAdapter()).getChildViewIDAt(index));
+        return ((FragmentAdapter) parent.getAdapter()).getChildViewAt(index);
     }
 
     @Override
     public void removeView(ViewPager2 parent, View view) {
-        reactChildrenViews.remove(view.getId());
         ((FragmentAdapter) parent.getAdapter()).removeFragment(view);
     }
 
 
     public void removeAllViews(ViewPager2 parent) {
         FragmentAdapter adapter = ((FragmentAdapter) parent.getAdapter());
-        for (int childID : adapter.getChildrenViewIDs()) {
-            reactChildrenViews.remove(childID);
-        }
         adapter.removeAll();
         parent.setAdapter(null);
     }
@@ -153,7 +147,6 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
     @Override
     public void removeViewAt(ViewPager2 parent, int index) {
         FragmentAdapter adapter = ((FragmentAdapter) parent.getAdapter());
-        reactChildrenViews.remove(adapter.getChildViewIDAt(index));
         adapter.removeFragmentAt(index);
     }
 

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ViewPagerFragment.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ViewPagerFragment.java
@@ -10,21 +10,16 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 public class ViewPagerFragment extends Fragment {
+    View view;
 
-    public static String CHILD_VIEW_KEY = "CHILD_VIEW_KEY";
-
-    public static ViewPagerFragment newInstance(int id) {
-        Bundle args = new Bundle();
-        args.putInt(CHILD_VIEW_KEY, id);
-        ViewPagerFragment fragment = new ViewPagerFragment();
-        fragment.setArguments(args);
-        return fragment;
+    public ViewPagerFragment(View child) {
+        view = child;
     }
 
 
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return ReactViewPagerManager.reactChildrenViews.get(getArguments().getInt(CHILD_VIEW_KEY));
+        return view != null ? view : new View(getContext());
     }
 }

--- a/src/ViewPager.tsx
+++ b/src/ViewPager.tsx
@@ -135,10 +135,7 @@ export class ViewPager extends React.Component<ViewPagerProps> {
   };
 
   private _onMoveShouldSetResponderCapture = () => {
-    if (Platform.OS === 'ios') {
-      return this.isScrolling;
-    }
-    return false;
+    return this.isScrolling;
   };
 
   render() {


### PR DESCRIPTION
# Summary
Fix for issue https://github.com/callstack/react-native-viewpager/issues/164
There are multiple solutions in issue i've tested this one and it works.
It contains also a few improvements like:
- remove unnecessary fork of ViewPager2
- change storing views approach on android

## Test Plan

![swipetouchables](https://user-images.githubusercontent.com/16048381/101041006-93fd4d00-357c-11eb-86e8-0c749c92346f.gif)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist


- [x] I have tested this on a device and a simulator
