### PR TITLE
fix: app crashing while setPage in componentDidMount on IOS

### DIFF
--- a/example/ios/ViewpagerExample.xcodeproj/project.pbxproj
+++ b/example/ios/ViewpagerExample.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 			children = (
 				871719007ECC5EAD276C345C /* Pods-ViewpagerExample.debug.xcconfig */,
 				4D7192F03A36A017E887435B /* Pods-ViewpagerExample.release.xcconfig */,
+				20F357AD24636CDE00C146DC /* ViewpagerExample-Bridging-Header.h */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -94,7 +95,6 @@
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				1CFFDEF7170271C97B8B7E5A /* Pods */,
-				20F357AD24636CDE00C146DC /* ViewpagerExample-Bridging-Header.h */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -155,6 +155,9 @@
                            with:(UIViewController *)controller
                       direction:(UIPageViewControllerNavigationDirection)direction
                        animated:(BOOL)animated {
+    if (self.reactPageViewController == nil) {
+        return;
+    }
     __weak ReactNativePageView *weakSelf = self;
     uint16_t coalescingKey = _coalescingKey++;
     


### PR DESCRIPTION
Partially fix problem from this issue https://github.com/callstack/react-native-viewpager/issues/167
# Summary

Problem exists only when value of `initialPage` is same as `setPage` executed from `componentDidMount`

## Test Plan


<details>
  <summary>Code which caused crash before</summary>

```ts
import React, {useRef, useState, useEffect} from 'react';
import {Image, StyleSheet, Text, View, SafeAreaView} from 'react-native';

import ViewPager from '@react-native-community/viewpager';

export default () => {
  const viewpagerRef = useRef(null);
  const [pages, setPages] = useState([
    <Image
      source={{uri: 'https://lorempixel.com/1080/1920/sports/2/'}}
      style={styles.image}
      key={1}
    />,
    <Image
      source={{uri: 'https://lorempixel.com/1080/1920/sports/4/'}}
      style={styles.image}
      key={2}
    />,
    <Image
      source={{uri: 'https://lorempixel.com/1080/1920/sports/9/'}}
      style={styles.image}
      key={3}
    />,
  ]);

  useEffect(() => {
    viewpagerRef.current.setPage(0);
  }, []);

  return (
    <SafeAreaView style={styles.container}>
      <ViewPager
        style={styles.viewPager}
        initialPage={0}
        pageMargin={10}
        orientation="vertical"
        transitionStyle="scroll"
        ref={viewpagerRef}>
        {pages}
      </ViewPager>
    </SafeAreaView>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  viewPager: {
    flex: 1,
  },
  image: {
    flex: 1,
    width: '100%',
  },
});
```
</details>


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
