### PR TITLE
Fix #183

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -58,7 +58,8 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
     protected ViewPager2 createViewInstance(@NonNull ThemedReactContext reactContext) {
         final ViewPager2 vp = new ViewPager2(reactContext);
         final FragmentAdapter adapter = new FragmentAdapter((FragmentActivity) reactContext.getCurrentActivity());
-        vp.setAdapter((FragmentStateAdapter) adapter);
+        vp.setAdapter(adapter);
+        //https://github.com/callstack/react-native-viewpager/issues/183
         vp.setSaveEnabled(false);
         eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         vp.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -59,6 +59,7 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
         final ViewPager2 vp = new ViewPager2(reactContext);
         final FragmentAdapter adapter = new FragmentAdapter((FragmentActivity) reactContext.getCurrentActivity());
         vp.setAdapter((FragmentStateAdapter) adapter);
+        vp.setSaveEnabled(false);
         eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         vp.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override


### PR DESCRIPTION
# Summary

Fix #183 
Enabled state for the view for some reason cause an issue with restoring screens.
As it's not necessary to save view state it will be disabled at the moment.

## Test Plan

https://github.com/callstack/react-native-viewpager/issues/183#issuecomment-647553382


