### PR TITLE
Fix #173

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -141,7 +141,6 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
     public void removeAllViews(ViewPager2 parent) {
         FragmentAdapter adapter = ((FragmentAdapter) parent.getAdapter());
         adapter.removeAll();
-        parent.setAdapter(null);
     }
 
     @Override


### PR DESCRIPTION
# Summary

Fix #173  
There is no reason to remove an adapter from the ViewPager instance when removing views as the new adapter is configured when the instance is created.

## Test Plan

Render the instance of ViewPager inside of `createNativeStackNavigator` screen.
Enter to the screen and try to leave it by clicking back.


