### PR TITLE
chore: add prop to disable/enable scroll bounces

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ const styles = StyleSheet.create({
 |`showPageIndicator: boolean`|Shows the dots indicator at the bottom of the view|iOS
 |`overScrollMode: OverScollMode`|Used to override default value of overScroll mode. Can be `auto`, `always` or `never`. Defaults to `auto`|Android
 |`offscreenPageLimit: number`|Set the number of pages that should be retained to either side of the currently visible page(s). Pages beyond this limit will be recreated from the adapter when needed. Defaults to RecyclerView's caching strategy. The given value must either be larger than 0.|Android
+|`overdrag: boolean`|Allows for overscrolling after reaching the end or very beginning or pages|iOS
 
 ## Preview
 

--- a/example/src/BasicViewPagerExample.tsx
+++ b/example/src/BasicViewPagerExample.tsx
@@ -18,6 +18,7 @@ export function BasicViewPagerExample() {
         ref={ref}
         style={styles.viewPager}
         initialPage={0}
+        overdrag={false}
         scrollEnabled={navigationPanel.scrollEnabled}
         onPageScroll={navigationPanel.onPageScroll}
         onPageSelected={navigationPanel.onPageSelected}

--- a/example/src/BasicViewPagerExample.tsx
+++ b/example/src/BasicViewPagerExample.tsx
@@ -18,7 +18,7 @@ export function BasicViewPagerExample() {
         ref={ref}
         style={styles.viewPager}
         initialPage={0}
-        overdrag={false}
+        overdrag={navigationPanel.overdragEnabled}
         scrollEnabled={navigationPanel.scrollEnabled}
         onPageScroll={navigationPanel.onPageScroll}
         onPageSelected={navigationPanel.onPageSelected}
@@ -41,6 +41,7 @@ export function BasicViewPagerExample() {
           [navigationPanel.pages]
         )}
       </AnimatedViewPager>
+
       <NavigationPanel {...navigationPanel} />
     </SafeAreaView>
   );

--- a/example/src/component/NavigationPanel/ControlPanel.tsx
+++ b/example/src/component/NavigationPanel/ControlPanel.tsx
@@ -13,12 +13,14 @@ export function ControlsPanel({
   dotsEnabled,
   progress,
   disablePagesAmountManagement,
+  overdragEnabled,
   setPage,
   addPage,
   removePage,
   toggleScroll,
   toggleDots,
   toggleAnimation,
+  toggleOverdrag,
 }: NavigationPanelProps) {
   const firstPage = useCallback(() => setPage(0), [setPage]);
   const prevPage = useCallback(() => setPage(activePage - 1), [
@@ -33,6 +35,7 @@ export function ControlsPanel({
     pages.length,
     setPage,
   ]);
+
   return (
     <>
       <View style={styles.buttons}>
@@ -45,6 +48,11 @@ export function ControlsPanel({
           text={dotsEnabled ? 'Hide dots' : 'Show dots'}
           onPress={toggleDots}
         />
+        <Button
+          style={styles.buttonAdjustment}
+          text={overdragEnabled ? 'Overdrag Enabled' : 'Overdrag Disabled'}
+          onPress={() => toggleOverdrag()}
+        />
       </View>
       {!disablePagesAmountManagement ? (
         <View style={styles.buttons}>
@@ -52,6 +60,7 @@ export function ControlsPanel({
           <Button text="Remove last page" onPress={removePage} />
         </View>
       ) : null}
+
       <View style={styles.buttons}>
         <Button
           text={isAnimated ? 'Turn off animations' : 'Turn animations back on'}

--- a/example/src/hook/useNavigationPanel.ts
+++ b/example/src/hook/useNavigationPanel.ts
@@ -29,6 +29,7 @@ export function useNavigationPanel(
   );
   const [activePage, setActivePage] = useState(0);
   const [isAnimated, setIsAnimated] = useState(true);
+  const [overdragEnabled, setOverdragEnabled] = useState(false);
   const [scrollEnabled, setScrollEnabled] = useState(true);
   const [scrollState, setScrollState] = useState('idle');
   const [dotsEnabled, setDotsEnabled] = useState(false);
@@ -68,6 +69,10 @@ export function useNavigationPanel(
   );
   const toggleDots = useCallback(
     () => setDotsEnabled((enabled) => !enabled),
+    []
+  );
+  const toggleOverdrag = useCallback(
+    () => setOverdragEnabled((enabled) => !enabled),
     []
   );
 
@@ -144,6 +149,7 @@ export function useNavigationPanel(
     scrollEnabled,
     dotsEnabled,
     progress,
+    overdragEnabled,
     setPage,
     addPage,
     removePage,
@@ -154,6 +160,7 @@ export function useNavigationPanel(
     onPageScroll,
     onPageSelected,
     onPageScrollStateChanged,
+    toggleOverdrag,
     logs,
   };
 }

--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) RCTDirectEventBlock onPageSelected;
 @property(nonatomic, copy) RCTDirectEventBlock onPageScroll;
 @property(nonatomic, copy) RCTDirectEventBlock onPageScrollStateChanged;
+@property(nonatomic) BOOL overdrag;
 
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;

--- a/ios/ReactViewPagerManager.m
+++ b/ios/ReactViewPagerManager.m
@@ -15,6 +15,8 @@ RCT_EXPORT_VIEW_PROPERTY(orientation, UIPageViewControllerNavigationOrientation)
 RCT_EXPORT_VIEW_PROPERTY(onPageSelected, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPageScroll, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPageScrollStateChanged, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(overdrag, BOOL)
+
 
 - (void) goToPage
                   : (nonnull NSNumber *)reactTag index

--- a/lib/typescript/example/src/component/NavigationPanel/ControlPanel.d.ts
+++ b/lib/typescript/example/src/component/NavigationPanel/ControlPanel.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="react" />
 import type { NavigationPanelProps } from './types';
-export declare function ControlsPanel({ activePage, isAnimated, pages, scrollState, scrollEnabled, dotsEnabled, progress, disablePagesAmountManagement, setPage, addPage, removePage, toggleScroll, toggleDots, toggleAnimation, }: NavigationPanelProps): JSX.Element;
+export declare function ControlsPanel({ activePage, isAnimated, pages, scrollState, scrollEnabled, dotsEnabled, progress, disablePagesAmountManagement, overdragEnabled, setPage, addPage, removePage, toggleScroll, toggleDots, toggleAnimation, toggleOverdrag, }: NavigationPanelProps): JSX.Element;

--- a/lib/typescript/example/src/hook/useNavigationPanel.d.ts
+++ b/lib/typescript/example/src/hook/useNavigationPanel.d.ts
@@ -19,6 +19,7 @@ export declare function useNavigationPanel(pagesAmount?: number, onPageSelectedC
         position: number;
         offset: number;
     };
+    overdragEnabled: boolean;
     setPage: (page: number) => void;
     addPage: () => void;
     removePage: () => void;
@@ -32,5 +33,6 @@ export declare function useNavigationPanel(pagesAmount?: number, onPageSelectedC
     onPageScroll: (...args: any[]) => void;
     onPageSelected: (...args: any[]) => void;
     onPageScrollStateChanged: (e: PageScrollStateChangedNativeEvent) => void;
+    toggleOverdrag: () => void;
     logs: EventLog[];
 };

--- a/lib/typescript/src/types.d.ts
+++ b/lib/typescript/src/types.d.ts
@@ -95,4 +95,9 @@ export interface ViewPagerProps {
      * Android only
      */
     overScrollMode?: OverScrollMode;
+    /**
+     * Determines whether it's possible to overscroll a bit
+     * after reaching end or very beginning of pages.
+     */
+    overdrag?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,4 +112,9 @@ export interface ViewPagerProps {
    * Android only
    */
   overScrollMode?: OverScrollMode;
+  /**
+   * Determines whether it's possible to overscroll a bit
+   * after reaching end or very beginning of pages.
+   */
+  overdrag?: boolean;
 }


### PR DESCRIPTION
# Summary
Closes #120  

It's a missing feature which was reverted in certain version which allows to disable/enable bounce effect while scrolling on iOS.
https://stackoverflow.com/questions/21798218/disable-uipageviewcontroller-bounce






