### PR TITLE
fix: clone children's instead of creating new ones

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -8,14 +8,14 @@
  * @flow strict-local
  */
 
-import React, { Children, ReactElement, ReactNode } from 'react';
+import React, { Children, ReactNode, ReactElement } from 'react';
 
 export const childrenWithOverriddenStyle = (children?: ReactNode) => {
   // Override styles so that each page will fill the parent. Native component
   // will handle positioning of elements, so it's not important to offset
   // them correctly.
   return Children.map(children, (child) => {
-    const { props, type } = child as ReactElement;
+    const { props } = child as ReactElement;
     const newProps = {
       ...props,
       style: [
@@ -32,6 +32,6 @@ export const childrenWithOverriddenStyle = (children?: ReactNode) => {
       ],
       collapsable: false,
     };
-    return React.createElement(type, newProps);
+    return React.cloneElement(child as ReactElement, newProps);
   });
 };


### PR DESCRIPTION
# Summary
Due to creating new children of ViewPager instance rather than cloning them we were losing properties like `ref`.
This issue is better described in #224.
