### PR TITLE
chore: add empty constructor

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/ViewPagerFragment.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ViewPagerFragment.java
@@ -16,6 +16,7 @@ public class ViewPagerFragment extends Fragment {
         view = child;
     }
 
+    public ViewPagerFragment() {}
 
     @Nullable
     @Override


### PR DESCRIPTION
# Summary

Basically it's an attempt to fix an issue reported in #283 and #282 which are seems to be related with restoring fragments state and creating ViewPagerFragment class without arguments.
Unfortunately, because this error not occurs on local environment, before we'll try to find some better solution we want to make sure that our guess is proper by implementing constructor without any arguments and check if it's helped.
