### PR TITLE
fix v5 regression: broken setPageWithoutAnimation

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -109,7 +109,7 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
                 view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
             }
         });
-        view.setCurrentItem(selectedTab);
+        view.setCurrentItem(selectedTab, scrollSmooth);
     }
 
 


### PR DESCRIPTION
# Summary

v5 regression

## Test Plan


### What are the steps to reproduce (after prerequisites)?

1. use setPageWithoutAnimation on Android
2. animation occurs

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator