### PR TITLE
fix (android): crash when scroll during unmount

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -139,6 +139,7 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
 
 
     public void removeAllViews(ViewPager2 parent) {
+        parent.setUserInputEnabled(false);
         FragmentAdapter adapter = ((FragmentAdapter) parent.getAdapter());
         adapter.removeAll();
     }

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -109,7 +109,7 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
                 view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
             }
         });
-        view.setCurrentItem(selectedTab);
+        view.setCurrentItem(selectedTab, scrollSmooth);
     }
 
 


### PR DESCRIPTION
# Summary

Similar bug to this: https://github.com/callstack/react-native-viewpager/pull/271

Longcat: `Scrapped or attached views may not be recycled`

Fix just removes touch event execution when component is unmounting. Maybe there is some nicer way to fix this error, but I haven't found it...

## Test Plan

Render the instance of ViewPager inside of createNativeStackNavigator screen.
Enter to the screen and try to leave it by clicking back and then (very fast) try to swipe (during the screen removal animation).

It's hard to reproduce this bug in simulator. The easiest way is to just add timeout to the screen with `goBack()` running after a few seconds.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
